### PR TITLE
Fix readme example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,29 +10,38 @@ Just like [serde_merge](https://crates.io/crates/serde_merge), this crate allows
 use serde_toml_merge::merge;
 use toml::Value;
 
-let first = r#"
+fn main() {
+    let first = r#"
 string = "foo"
 integer = 42
 float = 42.24
 boolean = true
 keep_me = true
-"#.parse::<Value>().unwrap();
+"#
+    .parse::<Value>()
+    .unwrap();
 
-let second = r#"
+    let second = r#"
 string = "bar"
 integer = 43
 float = 24.42
 boolean = false
 missing = true
-"#.parse::<Value>().unwrap();
+"#
+    .parse::<Value>()
+    .unwrap();
 
-let expected = r#"
+    let expected = r#"
+string = "bar"
 integer = 43
 float = 24.42
 boolean = false
 keep_me = true
 missing = true
-"#.pare::<Value>().unwrap();
+"#
+    .parse::<Value>()
+    .unwrap();
 
-assert_eq!(merge(first, second).unwrap(), expected);
+    assert_eq!(merge(first, second).unwrap(), expected);
+}
 ```


### PR DESCRIPTION
- fix missing string = "bar"
- fix typo `pare` -> `parse`
- added a main to allow easy copy/paste of example