### PR TITLE
Implement std::error::Error for serde_toml_merge::Error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@ impl Error {
     }
 }
 
+impl std::error::Error for Error {}
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(


### PR DESCRIPTION
Hello!

Small modification that makes functions returning a generic `Result<(), Box<dyn Error>>` not break when returning your error type.